### PR TITLE
Do not normalize absolute URLs. Fixes #33

### DIFF
--- a/src/requests/utils.ts
+++ b/src/requests/utils.ts
@@ -49,9 +49,17 @@ export function apiRequest(
     'X-CSRFToken': Cookies.get('csrftoken'),
     ...headers,
   };
+
+  let myPath;
+  if (url.split(/:\/\//).length > 1) {
+    myPath = url;
+  } else {
+    myPath = path.normalize(url);
+  }
+
   return axios({
     method,
-    url: path.normalize(url),
+    url: myPath,
     data,
     headers: combinedHeaders,
     onUploadProgress,

--- a/tests/requests.ts
+++ b/tests/requests.ts
@@ -178,6 +178,15 @@ describe('Requests', () => {
         expect((request as any).params.url).toEqual('/api/llama/');
       });
 
+      it('should not normalize absolute URLs', () => {
+        request = dispatchGenericRequest(
+          ACTION_SET,
+          'http://www.test.com',
+          METHOD
+        )(dispatch, getState) as any;
+        expect((request as any).params.url).toEqual('http://www.test.com');
+      });
+
       it('should dispatch success actions', () => {
         request.success({
           data: 'llama',


### PR DESCRIPTION
Do not normalize absolute URLs, as normalizing ruins it alllll.

Fixes #33