### PR TITLE
Use action meta page number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/redux-api-collections",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Type-safe helpers for dealing with Rest-Framework backed collections in Typescript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/collections/reducers.ts
+++ b/src/collections/reducers.ts
@@ -30,7 +30,7 @@ function updateCollectionItemsFromResponse<T extends IdKeyed>(
     ordering,
     reverseOrdering,
   } = action.meta;
-  const { count, next, results, page } = action.payload;
+  const { count, next, results } = action.payload;
 
   const oldCollectionItems = (collectionData[subgroup || ''] || { results: [] })
     .results;
@@ -44,7 +44,7 @@ function updateCollectionItemsFromResponse<T extends IdKeyed>(
     filters,
     next,
     ordering,
-    page: page || 1,
+    page: action.meta.page || action.payload.page || 1,
     results: newCollectionResults,
     immutableResults: useImmutable ? List<T>(newCollectionResults) : null,
     reverseOrdering,

--- a/tests/collections.ts
+++ b/tests/collections.ts
@@ -48,13 +48,14 @@ describe('Collections', () => {
     results: ReadonlyArray<any>,
     shouldAppend: boolean,
     count?: number,
+    metaPage?: number,
     next?: string
   ) {
     return {
-      meta: { tag, shouldAppend, subgroup },
+      meta: { tag, shouldAppend, subgroup, page: metaPage },
       payload: {
         count,
-        page: 1,
+        page: metaPage ? undefined : 1,
         next,
         results,
       },
@@ -317,6 +318,29 @@ describe('Collections', () => {
       expect(results).toBe(subCollection.results);
       expect(results.length).toBe(subCollection.count);
       expect(results[0].furLength).toBe(5);
+    });
+
+    it('should update the page from the GET_COLLECTION request meta if the server does not return the page number', () => {
+      const data = collections.reducers.collectionsReducer(
+        undefined,
+        getCollectionSuccess(
+          'llamas',
+          '',
+          [
+            {
+              furLength: 5,
+              id: '1',
+              name: 'Drama',
+            },
+          ],
+          false,
+          12,
+          6
+        )
+      );
+      const subCollection = getCollectionByName(data, 'llamas');
+      expect(subCollection.page).toBe(6);
+      expect(subCollection.count).toBe(12);
     });
 
     it('should add an item on ADD_TO_COLLECTION responses', () => {


### PR DESCRIPTION
Default the page number to the one supplied in the get collection action meta if the server does not supply a page number in its response