### PR TITLE
Dependency and ignore updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /coverage/*
 /dist/*
 /examples/build/*
+/.vscode/*
 
 .DS_Store
 npm-debug.log*

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,8 @@
-!dist/*
+/node_modules/*
+/coverage/*
+!/dist/*
+/examples/build/*
+/.vscode/*
+
+.DS_Store
+npm-debug.log*

--- a/package-lock.json
+++ b/package-lock.json
@@ -218,9 +218,9 @@
       }
     },
     "@dabapps/redux-requests": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@dabapps/redux-requests/-/redux-requests-0.5.4.tgz",
-      "integrity": "sha512-kHYQ0ODMr0x4zGWIWqUJO7s9kzuQotPOMwab5Yep56UQBZBui5ka56hVVLy1AKcCgGdFsq3Ck5+Z+C4WVFqCrQ==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@dabapps/redux-requests/-/redux-requests-0.5.5.tgz",
+      "integrity": "sha512-Vwr3CJr3agUjjEY9N7f60EvxuDIYUZ0ygflmY/6g645Gg9T5EnGznWW7pRYxSc2sWrJsDOcZZdSpl9bFjC5eeQ==",
       "requires": {
         "@types/js-cookie": "^2.0.28",
         "@types/node": "^7.0.18",
@@ -228,15 +228,8 @@
         "flux-standard-action": "^1.2.0",
         "js-cookie": "^2.1.4",
         "path": "^0.12.7",
-        "redux": "^3.7.2",
-        "redux-thunk": "^2.3.0"
-      },
-      "dependencies": {
-        "redux-thunk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
-          "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
-        }
+        "redux": "*",
+        "redux-thunk": "*"
       }
     },
     "@jest/console": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/redux-api-collections",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "typescript": "^3.3.3333"
   },
   "peerDependencies": {
-    "redux-thunk": ">= 2 < 3",
-    "redux": ">= 3 < 4"
+    "redux": "*",
+    "redux-thunk": "*"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "js-cookie": "^2.1.4",
     "path": "^0.12.7",
     "path-to-regexp": "^2.1.0",
-    "redux": "^3.7.2",
-    "redux-thunk": "^2.2.0",
+    "redux": "*",
+    "redux-thunk": "*",
     "underscore": "^1.8.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepublishOnly": "npm test && npm run dist"
   },
   "dependencies": {
-    "@dabapps/redux-requests": "^0.5.4",
+    "@dabapps/redux-requests": "^0.5.5",
     "@types/js-cookie": "^2.0.28",
     "@types/node": "^7.0.18",
     "@types/underscore": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/redux-api-collections",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Type-safe helpers for dealing with Rest-Framework backed collections in Typescript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
* Ignore vscode directory
* Update npmignore to mirror gitignore (minus the dist directory)
* Unpin peer dependencies (no usage of breaking changes)
* Upgrade redux-requests (to gain same changes)