### PR TITLE
Fix addCollectionItem

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/redux-api-collections",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dabapps/redux-api-collections",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Type-safe helpers for dealing with Rest-Framework backed collections in Typescript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/collections/reducers.ts
+++ b/src/collections/reducers.ts
@@ -100,7 +100,7 @@ export function addCollectionItem<T extends IdKeyedMap<T>>(
         subgroup
       );
       const results = existingCollection.results.concat([
-        recordBuilder(action.payload),
+        recordBuilder(action.payload.data),
       ]);
       const updatedCollection = {
         ...existingCollection,

--- a/tests/collections.ts
+++ b/tests/collections.ts
@@ -369,9 +369,11 @@ describe('Collections', () => {
       const data2 = collections.reducers.collectionsReducer(
         data,
         addItemSuccess('llamas', '', {
-          furLength: 10,
-          id: '2',
-          name: 'Pajama',
+          data: {
+            furLength: 10,
+            id: '2',
+            name: 'Pajama',
+          },
         })
       );
       const subCollection = getCollectionByName(data2, 'llamas');


### PR DESCRIPTION
**Adding an item to a collection was broken.**

_Problem_
It was adding the whole payload (including headers and meta) rather than just the data.

_Fix_
Fixed by providing `action.payload.data` instead of `action.payload` to `recordBuilder`